### PR TITLE
Table Header Z-index

### DIFF
--- a/src/components/Fields.tsx
+++ b/src/components/Fields.tsx
@@ -56,7 +56,6 @@ export const StickyHeader = styled(TableHeaderCell)`
   @supports (position: sticky) {
     position: sticky;
     top: 0;
-    z-index: 2;
 }
 `;
 


### PR DESCRIPTION
Remove the z-index because the table header is overlaying the DrawerDetail.
